### PR TITLE
Feature prefixes

### DIFF
--- a/components/codeGeneratorModal.tsx
+++ b/components/codeGeneratorModal.tsx
@@ -1,4 +1,4 @@
-import { Box, Counter, Flex, Form, FormGroup, Input, InputProps, Message, Modal, ModalAction, ProgressBar, Stepper, Text } from '@bigcommerce/big-design'
+import { Box, Counter, Form, FormGroup, Input, InputProps, Message, Modal, ModalAction, ProgressBar, Stepper, Text } from '@bigcommerce/big-design'
 import { ReactElement, useState } from 'react';
 import { makeDataUrl } from '@lib/util';
 import { useSession } from '../context/session'

--- a/lib/coupons.ts
+++ b/lib/coupons.ts
@@ -13,11 +13,11 @@ export function makeCode(length: number, codes: string[] = []): string {
     return result
 }
 
-export function generateCodes(quantity: number, length:number): string[] {     
+export function generateCodes(quantity: number, length:number, prefix:string = ""): string[] {     
     const codes = []
 
     for (let i = 0; i < quantity; i++) {
-        const code = makeCode(length, codes)
+        const code = prefix + makeCode(length, codes)
         codes.push(code)
     }
 

--- a/lib/coupons.ts
+++ b/lib/coupons.ts
@@ -13,7 +13,7 @@ export function makeCode(length: number, codes: string[] = []): string {
     return result
 }
 
-export function generateCodes(quantity: number, length:number, prefix:string = ""): string[] {     
+export function generateCodes(quantity: number, length:number, prefix = ""): string[] {     
     const codes = []
 
     for (let i = 0; i < quantity; i++) {


### PR DESCRIPTION
## What?
- Implements a new input in the coupon generator modal wherein the user may add a prefix for all coupon codes
- Limits the max length of the input to the max coupon length (50) minus the code length
- Limits the max value for length to the max coupon length (50) minus the prefix length

## Why?
Supplying a prefix for coupons in a given promotion is a common feature request

## Testing / Proof
Tested in local dev environment and heroku deployment prior to merging.
